### PR TITLE
General major-version dependency update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/
 
 # Directory created by dartdoc
 doc/api/
+
+# SDK directories
+.idea

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,12 @@ environment:
   sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
-  basic_utils: ^2.4.7
-  intl: ^0.16.0
-  mailer: ^3.0.4
-  mysql1: ^0.17.1
+  analyzer: ^4.0.0
+  basic_utils: ^4.2.1
+  intl: ^0.17.0
+  mailer: ^5.1.0
+  meta: ^1.7.0
+  mysql1: ^0.19.2
 
 dev_dependencies:
   pedantic: ^1.9.0


### PR DESCRIPTION
I need e.g. intl: ^0.17.0 for my project. I ran

> flutter pub upgrade --major-versions

All tests are green. Did not do further tests but will do so while using it shortly.