### PR TITLE
Fix for the meta version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   basic_utils: ^5.6.1
   intl: ^0.18.1
   mailer: ^6.0.1
-  meta: ^1.11.0
+  meta: ^1.9.0
   mysql1: ^0.20.0
   coverage: ^1.7.0
   vm_service: ^12.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.16.0 < 4.0.0'
 
 dependencies:
-  analyzer: ^6.3.0
+  analyzer: ^6.2.0
   basic_utils: ^5.6.1
   intl: ^0.18.1
   mailer: ^6.0.1


### PR DESCRIPTION
Flutter pub upgrade fails with a version mismatch

```
Because every version of flutter_test from sdk depends on meta 1.9.1 and every version of log_4_dart_2 from git depends on meta ^1.11.0, flutter_test from sdk is incompatible with log_4_dart_2 from git.
So, because greylock depends on both log_4_dart_2 from git and flutter_test from sdk, version solving failed.
```